### PR TITLE
Correcting d435 camera extrinsics

### DIFF
--- a/gazebo/models/d435/d435.sdf
+++ b/gazebo/models/d435/d435.sdf
@@ -105,7 +105,7 @@
             <pose>0 0.0175 0.0125 0 -0 0</pose>
          </sensor>
          <sensor name="cameraired2" type="camera">
-            <pose>0 0.05 0 0 0 0</pose>
+            <pose>0 -0.05 0 0 0 0</pose>
             <camera name="camera">
                <horizontal_fov>1.500</horizontal_fov>
                <image>


### PR DESCRIPTION
According to the current SDF, infra1 is right while infra2 is left camera for D435 in simulation, while it is the opposite in reality. This creates confusion in certain situations, e.g. while testing stereo SLAM algorithms. Hence correcting the same.