### PR TITLE
Parametrise update_rate

### DIFF
--- a/src/keyboard_ctl.cpp
+++ b/src/keyboard_ctl.cpp
@@ -141,9 +141,11 @@ int main(int argc, char **argv)
   nh.getParam("velocity_horizon", h_speed);
   nh.getParam("velocity_vertical", v_speed);
   nh.getParam("angular_velocity_turn", turn_speed);
+  nh.getParam("update_rate", update_rate);
   cout << "horizon speed: " <<  h_speed << endl;
   cout << "vertical speed: " << v_speed << endl;
   cout << "turning speed: " <<  turn_speed << endl;
+  cout << "update rate: " <<  update_rate << endl;
 
   ros::Subscriber state_sub = nh.subscribe<mavros_msgs::State>
       ("/mavros/state", 10, state_cb);


### PR DESCRIPTION
Parametrise update_rate so it can be configured without compiling as increasing this value may avoid latency in the motion.